### PR TITLE
Update React 16 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0  || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
Updates React 16 peer dependency to work with versions up to 18 so as not to break strict dependency checks in newer NPM versions